### PR TITLE
usePaginatedList

### DIFF
--- a/src/users/utils/usePagination.js
+++ b/src/users/utils/usePagination.js
@@ -6,22 +6,45 @@ function getChunks(fullList, chunkSize) {
     let newChunk = fullList.slice(idx, idx + chunkSize);
     paginatedList.push(newChunk);
   }
+  return paginatedList;
 }
-
-// const paginatedList = React.useMemo(() => {
-//   return getChunks(fullList);
-// }, [fullListUpdatedAtTimeStamp]);
 
 function getPageOfItems(chunkSize, pageNumber, fullList) {
   const firstItemOfSelectedPage = pageNumber * chunkSize;
   const lastItemOfSelectedPage = pageNumber * chunkSize + chunkSize;
   return fullList.slice(firstItemOfSelectedPage, lastItemOfSelectedPage);
 }
+
+export function usePaginatedList(
+  _fullList = [],
+  _pageNumber = 0,
+  _pageSize = 5
+) {
+  const [pageSize, setPageSize] = React.useState(() => _pageSize);
+  const [pageNumber, setPageNumber] = React.useState(() => _pageNumber);
+  const [fullList, setFullList] = React.useState(() => _fullList);
+
+  const [paginatedList, pageOfItems] = React.useMemo(() => {
+    const paginatedList = getChunks(fullList, pageSize);
+    return [paginatedList, paginatedList[pageNumber]];
+  }, [fullList, pageNumber, pageSize]);
+
+  return {
+    paginatedList,
+    pageOfItems,
+    pageSize,
+    pageNumber,
+    fullList,
+    setPageSize,
+    setPageNumber,
+    setFullList
+  };
+}
+
 export function usePagination(
   _pageSize = 5,
   _pageNumber = 0,
   _fullListOfIds = []
-  // listUpdatedAtTimeStamp = Date.now()
 ) {
   const [pageSize, setPageSize] = React.useState(() => _pageSize);
   const [pageNumber, setPageNumber] = React.useState(() => _pageNumber);


### PR DESCRIPTION
adds custom hook usePaginatedList
usecase: less freqent updates & smaller lists where parsing the whole thing @ once is feasible. return entire list broken into pages.
usePagination usecase:  frequent updates & extremely large lists. return selected pageOfItems for current data